### PR TITLE
All fixed now.

### DIFF
--- a/stories/components/Test.stories.js
+++ b/stories/components/Test.stories.js
@@ -1,13 +1,13 @@
 import Vuex from 'vuex'
 import { storiesOf } from '@storybook/vue'
 import Test from '../../components/Test'
-import { state } from '../../store/storetest'
+import * as storetest from '../../store/storetest'
 
 storiesOf(`Test`, module)
   .add(
     `Test`,
     () => ({
-      store: new Vuex.Store({ state: state() }),
+      store: new Vuex.Store({ modules: { storetest } }),
       components: {
         Test
       },


### PR DESCRIPTION
Hey there @rdelga80 ! So, here's a quick break down of your problem.

In nuxt, for each file/folder you create in the store folder, nuxt generates a vuex _module_. So, when you call `...mapState({ test: state => state.teststore.test})` the `teststore` part is the module name. The problem was, when you initialized your store in storybook, you were initializing the teststore as the root of the store, rather than a module. To fix this, I simply nested all the exports of `teststore.js` under the `modules` property of your `new Vuex()` constructor. And that fixed the issue. You could also, for the purpose of testing your story, leave `teststore` as the root module of your vuex store, and just use `...mapState({test: state => state.test})`. Either one should work!

Let me know if you have any other question!